### PR TITLE
Adding the missing error methods

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,12 +8,17 @@ func (e clientError) Error() string {
 	return e.message
 }
 
+func (e clientError) ClientError() bool {
+	return true
+}
+
 type timeoutError struct {
 }
 
 func (e timeoutError) Error() string {
 	return "The operation has timed out."
 }
+
 func (e timeoutError) Timeout() bool {
 	return true
 }

--- a/gocbcore/error.go
+++ b/gocbcore/error.go
@@ -12,6 +12,10 @@ func (e generalError) Error() string {
 	return e.message
 }
 
+func (e generalError) GeneralError() bool {
+	return true
+}
+
 type networkError struct {
 }
 
@@ -30,8 +34,24 @@ func (e overloadError) Error() string {
 	return "Queue overflow."
 }
 
+func (e overloadError) OverloadError() bool {
+	return true
+}
+
 type memdError struct {
 	code StatusCode
+}
+
+type agentError struct {
+	message string
+}
+
+func (e agentError) Error() string {
+	return e.message
+}
+
+func (e agentError) AgentError() bool {
+	return true
 }
 
 func (e memdError) Error() string {
@@ -64,23 +84,62 @@ func (e memdError) Error() string {
 		return fmt.Sprintf("An unknown error occurred (%d).", e.code)
 	}
 }
+
+func (e memdError) Success() bool {
+	return e.code == StatusSuccess
+}
+
 func (e memdError) KeyNotFound() bool {
 	return e.code == StatusKeyNotFound
 }
+
 func (e memdError) KeyExists() bool {
 	return e.code == StatusKeyExists
 }
+
+func (e memdError) TooBig() bool {
+	return e.code == StatusTooBig
+}
+
+func (e memdError) NotStored() bool {
+	return e.code == StatusNotStored
+}
+
+func (e memdError) BadDelta() bool {
+	return e.code == StatusBadDelta
+}
+
+func (e memdError) NotMyVBucket() bool {
+	return e.code == StatusNotMyVBucket
+}
+
 func (e memdError) Temporary() bool {
 	return e.code == StatusOutOfMemory || e.code == StatusTmpFail
 }
+
 func (e memdError) AuthError() bool {
 	return e.code == StatusAuthError
 }
 
-type agentError struct {
-	message string
+func (e memdError) AuthContinue() bool {
+	return e.code == StatusAuthContinue
 }
 
-func (e agentError) Error() string {
-	return e.message
+func (e memdError) UnknownCommand() bool {
+	return e.code == StatusUnknownCommand
+}
+
+func (e memdError) UnknownError() bool {
+	return e.code != StatusSuccess &&
+		e.code != StatusKeyNotFound &&
+		e.code != StatusKeyExists &&
+		e.code != StatusTooBig &&
+		e.code != StatusNotStored &&
+		e.code != StatusBadDelta &&
+		e.code != StatusNotMyVBucket &&
+		e.code != StatusAuthError &&
+		e.code != StatusAuthContinue &&
+		e.code != StatusUnknownCommand &&
+		e.code != StatusOutOfMemory &&
+		e.code != StatusTmpFail
 }


### PR DESCRIPTION
While there is still discussion in my previous pull request thread (https://github.com/couchbaselabs/gocb/pull/1), I thought it would be beneficial to have a complete set of error methods available to developers.

I've added all the methods that were missing from `errors.go` and `gocbcore/error.go`, and tracked here: https://issues.couchbase.com/browse/GOCBC-26