### PR TITLE
Fix panics when passing an interface{} to a bucket

### DIFF
--- a/transcoding_test.go
+++ b/transcoding_test.go
@@ -90,6 +90,23 @@ func TestDecodeBadType(t *testing.T) {
 	}
 }
 
+func TestDecodeToInterface(t *testing.T) {
+	var testOut interface{}
+	testDecode(t, jsonNumStr, 0x2000000, &testOut)
+	switch testOut := testOut.(type) {
+	case int:
+		if testOut != 2222 {
+			t.Errorf("Decoding failed")
+		}
+	case float64:
+		if testOut != 2222 {
+			t.Errorf("Decoding failed")
+		}
+	default:
+		t.Errorf("Decoding failed")
+	}
+}
+
 func TestEncodeJson(t *testing.T) {
 	testIn := make(map[string]string)
 	testIn["test"] = "value"


### PR DESCRIPTION
If a bucket has a string value for a particular key, it will panic if you do the following:
```go
var i interface{}
cas, err := bucket.Get(key, &i)
```
because the transcoder is casting an interface to a string.

This patch adds a type switch so that, if the wrong type is passed, the transcoder returns an error instead of panicking.