### PR TITLE
change err to var

### DIFF
--- a/gocbcore/agent.go
+++ b/gocbcore/agent.go
@@ -270,7 +270,7 @@ func (agent *Agent) Close() {
 	//   requests as errors (this also closes the server conn).
 	for _, s := range routingInfo.servers {
 		s.Drain(func (req *memdQRequest) {
-			req.Callback(nil, shutdownError{})
+			req.Callback(nil, ShutdownError)
 		})
 	}
 
@@ -278,12 +278,12 @@ func (agent *Agent) Close() {
 	//   requests which are not pending on a server queue.
 	if routingInfo.deadQueue != nil {
 		routingInfo.deadQueue.Drain(func (req *memdQRequest) {
-			req.Callback(nil, shutdownError{})
+			req.Callback(nil, ShutdownError)
 		}, nil)
 	}
 	if routingInfo.waitQueue != nil {
 		routingInfo.waitQueue.Drain(func (req *memdQRequest) {
-			req.Callback(nil, shutdownError{})
+			req.Callback(nil, ShutdownError)
 		}, nil)
 	}
 }

--- a/gocbcore/agentdcp.go
+++ b/gocbcore/agentdcp.go
@@ -85,7 +85,7 @@ func (c *Agent) OpenStream(vbId uint16, vbUuid VbUuid, startSeqNo, endSeqNo, sna
 		case CmdDcpStreamEnd:
 			vbId := uint16(resp.Status)
 			code := StreamEndStatus(binary.BigEndian.Uint32(resp.Extras[0:]))
-			evtHandler.End(vbId, streamEndError{code})
+			evtHandler.End(vbId, getStreamEndError(code))
 			req.Cancel()
 		}
 	}

--- a/gocbcore/agenthttpcfg.go
+++ b/gocbcore/agenthttpcfg.go
@@ -103,7 +103,7 @@ func (c *Agent) httpLooper(firstCfgFn func(*cfgBucket, error)) {
 		if resp.StatusCode != 200 {
 			if resp.StatusCode == 401 {
 				logDebugf("Failed to connect to host, bad auth.")
-				firstCfgFn(nil, &memdError{StatusAuthError})
+				firstCfgFn(nil, getMemdError(StatusAuthError))
 				return
 			}
 			logDebugf("Failed to connect to host, unexpected status code: %v.", resp.StatusCode)

--- a/gocbcore/agentrouting.go
+++ b/gocbcore/agentrouting.go
@@ -465,6 +465,6 @@ func (c *Agent) redispatchDirect(req *memdQRequest) {
 	} else {
 		// Callback advising that a network failure caused this operation to
 		//   not be processed, nothing outside the agent should really see this.
-		req.Callback(nil, networkError{})
+		req.Callback(nil, NetworkError)
 	}
 }

--- a/gocbcore/memdqueue.go
+++ b/gocbcore/memdqueue.go
@@ -72,7 +72,7 @@ func (s *memdQueue) QueueRequest(req *memdQRequest) bool {
 		s.lock.RUnlock()
 		// As long as we have not lost ownership, dispatch a queue overflow error.
 		if atomic.CompareAndSwapPointer(&req.queuedWith, unsafe.Pointer(s), nil) {
-			req.Callback(nil, overloadError{})
+			req.Callback(nil, OverloadError)
 		}
 		return true
 	}


### PR DESCRIPTION
Hello,I change errors to var value and make it publish.These is 2 reason.

* it can reduce error var number when a log of error happen.It always use the same errors.
* it make error easier to compare and deal with,before,when I need to deal with KeyNotFound ,I had to write code like:

```
    if err.Error() == "Key not found" {...}
```

but after it's publiced,it can be

```
    if err == gocbcore.KeyNotFoundError {...}
```

it's more extensible when error message change.