### PR TITLE
Explicitly remove reference of bucketInternal in Bucket

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -110,6 +110,7 @@ func (b *Bucket) getN1qlEp() (string, error) {
 
 func (b *Bucket) Close() {
 	b.client.Close()
+	b.internal = nil
 }
 
 func (b *Bucket) IoRouter() *gocbcore.Agent {


### PR DESCRIPTION
I had a memory leak on newly published server. I profiled my app and noticed that the Bucket.internal variable makes self reference to Bucket at creation.
https://github.com/couchbase/gocb/blob/b3a6cdbfe7fd3f3fa44f55f3b75383fa019ed59b/bucket.go#L48

It caused memory leak on every bucket opening. Thus It should be cleaned up in Bucket.Close function.