### PR TITLE
clean up golint messages on Exported methods within bucket.go

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// An interface representing a single bucket within a cluster.
+// Bucket is an interface representing a single bucket within a cluster.
 type Bucket struct {
 	name     string
 	password string
@@ -51,35 +51,49 @@ func createBucket(config *gocbcore.AgentConfig) (*Bucket, error) {
 	return bucket, nil
 }
 
+// OperationTimeout returns the int64 Duration encoded timeout for accessing a Bucket
 func (b *Bucket) OperationTimeout() time.Duration {
 	return b.opTimeout
 }
+
+// SetOperationTimeout allows for setting a Bucket timeout with an int64 time.Duration
 func (b *Bucket) SetOperationTimeout(timeout time.Duration) {
 	b.opTimeout = timeout
 }
+
+// DurabilityTimeout returns the specified Bucket durability timeout in int64 time.Duration
 func (b *Bucket) DurabilityTimeout() time.Duration {
 	return b.duraTimeout
 }
+
+// SetDurabilityTimeout specifies the Bucket durability timeout via an int64 time.Duration
 func (b *Bucket) SetDurabilityTimeout(timeout time.Duration) {
 	b.duraTimeout = timeout
 }
+
+// DurabilityPollTimeout returns the specified Bucket durability poll timeout in int64 time.Duration
 func (b *Bucket) DurabilityPollTimeout() time.Duration {
 	return b.duraPollTimeout
 }
+
+// SetDurabilityPollTimeout sets the specified Bucket's durability poll timeout via an int64 time.Duration
 func (b *Bucket) SetDurabilityPollTimeout(timeout time.Duration) {
 	b.duraPollTimeout = timeout
 }
 
+// SetTranscoder sets the Bucket's transcoder
 func (b *Bucket) SetTranscoder(transcoder Transcoder) {
 	b.transcoder = transcoder
 }
 
+// InvalidateQueryCache Invalidates and clears the query cache. This method can be used to explicitly clear the internal N1QL query cache. This cache will be filled with non-adhoc query statements (query plans) to speed up those subsequent executions. Triggering this method will wipe out the complete cache, which will not cause an interruption but rather all queries need to be re-prepared internally. This method is likely to be deprecated in the future once the server side query engine distributes its state throughout the cluster.
 func (b *Bucket) InvalidateQueryCache() {
 	b.queryCacheLock.Lock()
 	b.queryCache = make(map[string]*n1qlCache)
 	b.queryCacheLock.Unlock()
 }
 
+// Cas is acronym for "Check and Set" and is useful for ensuring that a mutation of a document by one user or thread does not override another near simultaneous mutation by another user or thread. The CAS value is returned by the server with the result when you perform a read on a document using Get or when you perform a mutation on a document using Insert, Upsert, Replace or Remove.
 type Cas gocbcore.Cas
 type pendingOp gocbcore.PendingOp
 
@@ -108,20 +122,24 @@ func (b *Bucket) getN1qlEp() (string, error) {
 	return n1qlEps[rand.Intn(len(n1qlEps))], nil
 }
 
+// Close the instance’s underlying socket resources.  Note that operations pending on the connection may fail.
 func (b *Bucket) Close() {
 	b.client.Close()
 }
 
+// IoRouter returns a pointer to the Bucket's client
 func (b *Bucket) IoRouter() *gocbcore.Agent {
 	return b.client
 }
 
-// *INTERNAL*
 // Internal methods, not safe to be consumed by third parties.
+// *INTERNAL*
+// TODO: gocb maintainers should make this unexported, and it shouldn't refer to an unexported type in return
 func (b *Bucket) Internal() *bucketInternal {
 	return b.internal
 }
 
+// Manager returns a pointer to a BucketManager
 func (b *Bucket) Manager(username, password string) *BucketManager {
 	return &BucketManager{
 		bucket:   b,


### PR DESCRIPTION
* add comments per golang conventions so the Exported methods within Bucket.go appear in Godoc

Running golint on gocb ‘master’ branch produces 186 lint errors.  While these don’t affect execution of the gocb package, they represent *undocumented* methods the package purposefully exports, and they do not show up in gocb's godoc.  The couchbase Go SDK docs event point to godoc as the reference developers should follow, but there is a gap in that these exported methods documented.  It also makes the library appear unfinished, or not adhering to some of the Golang conventions prescribed by golint.

This pull request document these exported methods on Bucket (for starters) for the benefit of the community, specifically:

```
[mholton@mh:~/Go/src/github.com/holtonma/gocb → fix_golint_exported_methods]$ golint
bucket.go:10:1: comment on exported type Bucket should be of the form "Bucket ..." (with optional leading article)
bucket.go:54:1: exported method Bucket.OperationTimeout should have comment or be unexported
bucket.go:57:1: exported method Bucket.SetOperationTimeout should have comment or be unexported
bucket.go:60:1: exported method Bucket.DurabilityTimeout should have comment or be unexported
bucket.go:63:1: exported method Bucket.SetDurabilityTimeout should have comment or be unexported
bucket.go:66:1: exported method Bucket.DurabilityPollTimeout should have comment or be unexported
bucket.go:69:1: exported method Bucket.SetDurabilityPollTimeout should have comment or be unexported
bucket.go:73:1: exported method Bucket.SetTranscoder should have comment or be unexported
bucket.go:77:1: exported method Bucket.InvalidateQueryCache should have comment or be unexported
bucket.go:83:6: exported type Cas should have comment or be unexported
bucket.go:111:1: exported method Bucket.Close should have comment or be unexported
bucket.go:115:1: exported method Bucket.IoRouter should have comment or be unexported
bucket.go:119:1: comment on exported method Bucket.Internal should be of the form "Internal ..."
bucket.go:121:29: exported method Internal returns unexported type *gocb.bucketInternal, which can be annoying to use
bucket.go:125:1: exported method Bucket.Manager should have comment or be unexported
```

If this PR is accepted, I'll take the time to clean up the rest of the golint messages on bucket_crud, bucket_dura, bucket_http, bucket_multi, bucket_subdoc, etc.  The full list of golint messages is in this gist: https://gist.github.com/holtonma/9aea53185f887496983a 