### PR TITLE
Imported and not used: "strings"

### DIFF
--- a/n1qlquery.go
+++ b/n1qlquery.go
@@ -2,7 +2,6 @@ package gocb
 
 import (
 	"time"
-	"strings"
 )
 
 type ConsistencyMode int


### PR DESCRIPTION
vendor/github.com/couchbase/gocb/n1qlquery.go:5: imported and not used: "strings"