### PR TITLE
add patch for 1.8.1 compatibility

### DIFF
--- a/gocbcore/routeconfig.go
+++ b/gocbcore/routeconfig.go
@@ -41,7 +41,7 @@ func (config *routeConfig) IsValid() bool {
 	}
 	switch config.bktType {
 	case BktTypeCouchbase:
-		return len(config.vbMap) > 0 && len(config.vbMap[0]) > 0 && len(config.capiEpList) > 0
+		return len(config.vbMap) > 0 && len(config.vbMap[0]) > 0
 	case BktTypeMemcached:
 		return len(config.ketamaMap) > 0
 	default:


### PR DESCRIPTION
Hey guys,

Wondering if you would be interested in accepting this patch. We are using 1.8.1, so our nodes do not have the `CouchAPIBase` attribute.

As far as I can tell this solves the issue, and I am able to write to and read from our production couchbase cluster.

Curious about your feedback, or if there's anything else I need to do as part of this patch to take advantage of the go client.

More details:

The server info JSON for our production couchbase 1.8.1 cluster includes node information, formatted like this:
```
$ curl http://localhost:21214/pools/default/bucketsStreaming/default
{
  "name":"default",
  "bucketType":"membase",
  ...snip
  "nodes":[{
    "replication":1.0,
    "clusterMembership":"active",
    "status":"healthy",
    "hostname":"127.0.0.1:8091",
    "clusterCompatibility":1,
    "version":"1.8.1...",
    "os":"...",
    "ports":{"proxy":11211,"direct":11210}
  },{
```
What is missing is the [Node.CouchAPIBase](http://docs.couchbase.com/sdk-api/couchbase-net-client-2.0.1/html/DD51ADF3.htm) property (according to the link, added in `2.0.1.0`).

If that property is not set, then in `routeconfig.go` we skip over this `if` statement:

```go
// routeconfig.go#buildRouteConfig
 			if node.CouchAPIBase != "" {
 				// Slice off the UUID as Go's HTTP client cannot handle being passed URL-Encoded path values.
 				capiEp := strings.SplitN(node.CouchAPIBase, "%2B", 2)[0]
 
 				capiEpList = append(capiEpList, capiEp)
  			}
```

This results in an invalid configuration, as the `capiEpList` is then empty.

```go
// from routeconfig.go
func (config *routeConfig) IsValid() bool {
	if len(config.kvServerList) == 0 || len(config.mgmtEpList) == 0 {
		return false
	}
	switch config.bktType {
	case BktTypeCouchbase:
		return len(config.vbMap) > 0 && len(config.vbMap[0]) > 0 && len(config.capiEpList) > 0
	case BktTypeMemcached:
		return len(config.ketamaMap) > 0
	default:
		return false
	}
}
```
The `case BktTypeCouchbase:` statement in particular is where our issue crops up.

The property is not present, so we do not append any servers to `config.capiEpList`.

The workaround is to simply append servers to the `capiEpList` if they are present (accomplished by the patch).  This code will append the servers to the `capiEpList` only if the length of the `capiEpList` is `0` (meaning it has not been populated).

This has been tested against our production 1.8.1 cluster and results in a valid configuration.

@StabbyCutyou @csmith0651 