### PR TITLE
Fix Bulk counter for negative Delta

### DIFF
--- a/bucket_multi.go
+++ b/bucket_multi.go
@@ -361,7 +361,7 @@ func (item *CounterOp) execute(b *Bucket, signal chan BulkOp) {
 			item.bulkOp.pendop = op
 		}
 	} else if item.Delta < 0 {
-		op, err := b.client.Increment([]byte(item.Key), uint64(-item.Delta), realInitial, item.Expiry,
+		op, err := b.client.Decrement([]byte(item.Key), uint64(-item.Delta), realInitial, item.Expiry,
 			func(value uint64, cas gocbcore.Cas, mutToken gocbcore.MutationToken, err error) {
 				item.Err = err
 				if item.Err == nil {


### PR DESCRIPTION
this patch fixes Counter bulk operation for a negative Delta.
I also discovered that operation fails when Initial=0  with following error:
"An unknown error occurred (4)"  
I guess some clarification is required for that in the documentation.

Greetings from Nexmo
