### PR TITLE
Fixed goroutine leak when using durability

### DIFF
--- a/bucket_dura.go
+++ b/bucket_dura.go
@@ -121,6 +121,10 @@ func (b *Bucket) observeOne(key []byte, mt MutationToken, cas Cas, forDelete boo
 				sentPersisted = true
 			}
 
+			if sentReplicated && sentPersisted {
+ 				return
+ 			}
+
 			waitTmr := gocbcore.AcquireTimer(b.duraPollTimeout)
 			select {
 			case <-waitTmr.C:
@@ -152,8 +156,8 @@ func (b *Bucket) durability(key string, cas Cas, mt MutationToken, replicaTo, pe
 
 	keyBytes := []byte(key)
 
-	replicaCh := make(chan bool)
-	persistCh := make(chan bool)
+	replicaCh := make(chan bool, numServers)
+	persistCh := make(chan bool, numServers)
 
 	for replicaIdx := 0; replicaIdx < numServers; replicaIdx++ {
 		go b.observeOne(keyBytes, mt, cas, forDelete, replicaIdx, replicaCh, persistCh)


### PR DESCRIPTION
When using durability functions, one goroutine per request for each replica is spawned and will never quit.
If the durability settings are set to maximum for both replica and persist, the leaking goroutine will poll couchbase for state every 100ms.

The function __observeOne__ is blocking, trying to send a message to either __replicaCh__ or __persistCh__, but the function __durability__ is not reading from these channels anymore once it reached the target durability settings.

By using buffered channels we ensure the writes are not blocking anymore, and once replicaCh and persistCh have been written, we can exit the goroutine.