### PR TITLE
Fixed missing cas in sub-document's LookupIn

### DIFF
--- a/bucket_subdoc.go
+++ b/bucket_subdoc.go
@@ -108,6 +108,7 @@ func (b *Bucket) lookupIn(set *LookupInBuilder) (resOut *DocumentFragment, errOu
 			{
 				resSet := &DocumentFragment{}
 				resSet.contents = make([]subDocResult, len(results))
+				resSet.cas = Cas(cas)
 
 				for i := range results {
 					resSet.contents[i].path = set.ops[i].Path


### PR DESCRIPTION
The sub-document function LookupIn always returns a zero cas.
This fix saves the cas in the resSet variable.