### PR TITLE
Fix BucketManager method GetDesignDocuments

### DIFF
--- a/bucketmgr.go
+++ b/bucketmgr.go
@@ -184,8 +184,8 @@ func (bm *BucketManager) GetDesignDocuments() ([]*DesignDocument, error) {
 	}
 
 	var ddocs []*DesignDocument
-	for _, ddocData := range ddocsObj.Rows {
-		ddoc := &ddocData.Doc.Json
+	for index, ddocData := range ddocsObj.Rows {
+		ddoc := &ddocsObj.Rows[index].Doc.Json
 		ddoc.Name = ddocData.Doc.Meta.Id[8:]
 		ddocs = append(ddocs, ddoc)
 	}


### PR DESCRIPTION
Range copies the value from the slice your iterating over resulted in the GetDesignDocuments method returning a list of identical pointers to the address that the range clause utilized.
See https://golang.org/ref/spec#RangeClause