### PR TITLE
don't set basic auth header when username and password are not supplied

### DIFF
--- a/clustermgr.go
+++ b/clustermgr.go
@@ -79,7 +79,9 @@ func (cm *ClusterManager) mgmtRequest(method, uri string, contentType string, bo
 		return nil, err
 	}
 
-	req.SetBasicAuth(cm.username, cm.password)
+	if cm.username != "" && cm.password != "" {
+		req.SetBasicAuth(cm.username, cm.password)
+	}
 	return cm.httpCli.Do(req)
 }
 


### PR DESCRIPTION
He had a bug when we were executing the following code. 

clusterMgr := cluster.Manager("", "")
buckets, err := clusterMgt.GetBuckets()

To an unsecured couchbase cluster. Apparently when the empty strings were being passed in the BasicAuth header was still being set which the server on the couchbase didn't like; it would return a 401 status code. Doing a plain GET request to the server would return the proper response. 