### PR TITLE
allow composite keys

### DIFF
--- a/viewquery.go
+++ b/viewquery.go
@@ -118,7 +118,7 @@ func (vq *ViewQuery) Key(key interface{}) *ViewQuery {
 }
 
 // Keys specifies a list of specific keys to retrieve from the index.
-func (vq *ViewQuery) Keys(keys []interface{}) *ViewQuery {
+func (vq *ViewQuery) Keys(keys interface{}) *ViewQuery {
 	jsonKeys := vq.marshalJson(keys)
 	vq.options.Set("keys", string(jsonKeys))
 	return vq


### PR DESCRIPTION
cannot use keys (type [][]interface) as type []interface {}

I want to use `[][]string`. cannot use as `[]interface{}`
```js
// e.g.
function (doc, meta) {
  emit([doc.param1, doc.param2], doc);
}
```