### PR TITLE
Fix durability for single node clusters

### DIFF
--- a/bucket_dura.go
+++ b/bucket_dura.go
@@ -191,7 +191,7 @@ func (b *Bucket) durability(tracectx opentracing.SpanContext, key string, cas Ca
 
 		if replicas >= replicaTo && persists >= persistTo {
 			return nil
-		} else if results == ((numServers * 2) - 1) {
+		} else if results == (numServers * 2) {
 			return ErrDurabilityTimeout
 		}
 	}


### PR DESCRIPTION
The durability function runs observeOne in goroutines for a mutation's master
node and its replicas. Each goroutine is provided with a channel to report
replication and persistence observations. There is careful handling to
ensure that each call to observeOne always writes one value to each channel.

durability selects on the channels and returns when it has detected the
minimum required number of successful replica and persistence writes.
It returns ErrDurabilityTimeout if not enough successes were detected.
However the condition for returning ErrDurabilityTimeout fails for a
single node on the first result returned since (numServers*2)-1 = 1 it
will always return ErrDurabilityTimeout if persistTo > 0 and it receives
on replicaCh before persistCh.

Since observeOne always writes to both channels the condition can be
adjusted to return ErrDurabilityTimeout only when 2*numServer values
have been received.