### PR TITLE
Fixing BucketManager DropPrimaryIndex call

### DIFF
--- a/bucketmgr.go
+++ b/bucketmgr.go
@@ -319,7 +319,7 @@ func (bm *BucketManager) dropIndex(indexName string, ignoreIfNotExists bool) err
 	var qs string
 
 	if indexName == "" {
-		qs += "DROP PRIMARY INDEX `" + bm.bucket.name + "`"
+		qs += "DROP PRIMARY INDEX ON `" + bm.bucket.name + "`"
 	} else {
 		qs += "DROP INDEX `" + bm.bucket.name + "`.`" + indexName + "`"
 	}


### PR DESCRIPTION
BucketManager.DropPrimaryIndex fails with the following error:

    [3000] syntax error - at `bucketname`

This should be a very simple fix, I have tested locally and it seems to address the issue..