### PR TITLE
[FIX] Type creation changed to type alias

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -140,4 +140,4 @@ func (ca CertAuthenticator) Credentials(req AuthCredsRequest) ([]UserPassPair, e
 
 // CertificateAuthenticator is included for backwards compatibility only.
 // Deprecated: Use CertAuthenticator instead.
-type CertificateAuthenticator CertAuthenticator
+type CertificateAuthenticator = CertAuthenticator


### PR DESCRIPTION
RP is recreated to give Gerrit right email.

You cannot use methods of the underlying type, and you have to use type aliases for that.
I suppose it is just a typo.

Please merge this fix ASAP because the package is broken after the previous merged PR.