### PR TITLE
fix a data race

### DIFF
--- a/thresholdlogtracer.go
+++ b/thresholdlogtracer.go
@@ -93,7 +93,7 @@ type thresholdLogService struct {
 	Top     []thresholdLogItem `json:"top"`
 }
 
-func (g *thresholdLogGroup) logRecordedRecords() {
+func (g *thresholdLogGroup) logRecordedRecords(size uint32) {
 	// Escape early if we have no ops to log...
 	g.lock.Lock()
 
@@ -106,7 +106,7 @@ func (g *thresholdLogGroup) logRecordedRecords() {
 	// our ops from actually being recorded in other goroutines (which would
 	// effectively slow down the op pipeline for logging).
 
-	oldOps := make([]*thresholdLogSpan, len(g.ops))
+	oldOps := make([]*thresholdLogSpan, 0, size)
 	copy(oldOps, g.ops)
 	g.ops = g.ops[:0]
 
@@ -190,11 +190,11 @@ func (t *ThresholdLoggingTracer) DecRef() int32 {
 func (t *ThresholdLoggingTracer) logRecordedRecords() {
 	logInfof("Threshold Log:")
 
-	t.kvGroup.logRecordedRecords()
-	t.viewsGroup.logRecordedRecords()
-	t.queryGroup.logRecordedRecords()
-	t.searchGroup.logRecordedRecords()
-	t.analyticsGroup.logRecordedRecords()
+	t.kvGroup.logRecordedRecords(t.SampleSize)
+	t.viewsGroup.logRecordedRecords(t.SampleSize)
+	t.queryGroup.logRecordedRecords(t.SampleSize)
+	t.searchGroup.logRecordedRecords(t.SampleSize)
+	t.analyticsGroup.logRecordedRecords(t.SampleSize)
 }
 
 func (t *ThresholdLoggingTracer) startLoggerRoutine() {

--- a/thresholdlogtracer.go
+++ b/thresholdlogtracer.go
@@ -94,15 +94,9 @@ type thresholdLogService struct {
 }
 
 func (g *thresholdLogGroup) logRecordedRecords() {
+	// Escape early if we have no ops to log...
 	g.lock.Lock()
 
-	// capacity is static for the group, no need for a lock
-	sampleSize := cap(g.ops)
-
-	// Preallocate space to copy the ops into...
-	oldOps := make([]*thresholdLogSpan, sampleSize)
-
-	// Escape early if we have no ops to log...
 	if len(g.ops) == 0 {
 		g.lock.Unlock()
 		return
@@ -112,7 +106,7 @@ func (g *thresholdLogGroup) logRecordedRecords() {
 	// our ops from actually being recorded in other goroutines (which would
 	// effectively slow down the op pipeline for logging).
 
-	oldOps = oldOps[0:len(g.ops)]
+	oldOps := make([]*thresholdLogSpan, len(g.ops))
 	copy(oldOps, g.ops)
 	g.ops = g.ops[:0]
 

--- a/thresholdlogtracer.go
+++ b/thresholdlogtracer.go
@@ -94,13 +94,14 @@ type thresholdLogService struct {
 }
 
 func (g *thresholdLogGroup) logRecordedRecords() {
+	g.lock.Lock()
+
 	// capacity is static for the group, no need for a lock
 	sampleSize := cap(g.ops)
 
 	// Preallocate space to copy the ops into...
 	oldOps := make([]*thresholdLogSpan, sampleSize)
 
-	g.lock.Lock()
 	// Escape early if we have no ops to log...
 	if len(g.ops) == 0 {
 		g.lock.Unlock()


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c4206987f8 by goroutine 30:
  gopkg.in/couchbase/gocb%2ev1.(*thresholdLogGroup).logRecordedRecords()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:98 +0x5f
  gopkg.in/couchbase/gocb%2ev1.(*ThresholdLoggingTracer).logRecordedRecords()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:198 +0x6c
  gopkg.in/couchbase/gocb%2ev1.(*ThresholdLoggingTracer).loggerRoutine()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:250 +0x4a

Previous write at 0x00c4206987f8 by goroutine 59:
  gopkg.in/couchbase/gocb%2ev1.(*thresholdLogGroup).recordOp()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:60 +0x499
  gopkg.in/couchbase/gocb%2ev1.(*ThresholdLoggingTracer).recordOp()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:261 +0xc2
  gopkg.in/couchbase/gocb%2ev1.(*thresholdLogSpan).Finish()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:408 +0x266
  gopkg.in/couchbase/gocb%2ev1.(*Bucket).Get()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/bucket_crud.go:13 +0x11b
  ... (private code)

Goroutine 30 (running) created at:
  gopkg.in/couchbase/gocb%2ev1.(*ThresholdLoggingTracer).startLoggerRoutine()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:242 +0x918
  gopkg.in/couchbase/gocb%2ev1.(*ThresholdLoggingTracer).AddRef()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/thresholdlogtracer.go:181 +0x78
  gopkg.in/couchbase/gocb%2ev1.tracerAddRef()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/tracing.go:14 +0x83
  gopkg.in/couchbase/gocb%2ev1.Connect()
      /Users/lloiser/go/src/gopkg.in/couchbase/gocb.v1/cluster.go:83 +0x439
  ... (private code)

Goroutine 59 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:824 +0x564
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1063 +0xa4
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:777 +0x16d
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1061 +0x4e1
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:978 +0x2cd
  main.main()
      _testmain.go:42 +0x22a
==================
```