### PR TITLE
Fix MatchAll and MatchNone query

### DIFF
--- a/cbft/query.go
+++ b/cbft/query.go
@@ -523,11 +523,14 @@ func NewMatchAllQuery() *MatchAllQuery {
 
 // MatchNoneQuery represents a FTS match none query.
 type MatchNoneQuery struct {
+	MatchNone map[string]string `json:"match_none"`
 }
 
 // NewMatchNoneQuery creates a new MatchNoneQuery.
 func NewMatchNoneQuery(prefix string) *MatchNoneQuery {
-	return &MatchNoneQuery{}
+	return &MatchNoneQuery{
+		MatchNone: make(map[string]string),
+	}
 }
 
 // TermRangeQuery represents a FTS term range query.

--- a/cbft/query.go
+++ b/cbft/query.go
@@ -511,26 +511,26 @@ func (q *PrefixQuery) Boost(boost float32) *PrefixQuery {
 
 // MatchAllQuery represents a FTS match all query.
 type MatchAllQuery struct {
-	MatchAll map[string]string `json:"match_all"`
+	ftsQueryBase
 }
 
 // NewMatchAllQuery creates a new MatchAllQuery.
 func NewMatchAllQuery() *MatchAllQuery {
-	return &MatchAllQuery{
-		MatchAll: make(map[string]string),
-	}
+	q := &MatchAllQuery{newFtsQueryBase()}
+	q.options["match_all"] = nil
+	return q
 }
 
 // MatchNoneQuery represents a FTS match none query.
 type MatchNoneQuery struct {
-	MatchNone map[string]string `json:"match_none"`
+	ftsQueryBase
 }
 
 // NewMatchNoneQuery creates a new MatchNoneQuery.
-func NewMatchNoneQuery(prefix string) *MatchNoneQuery {
-	return &MatchNoneQuery{
-		MatchNone: make(map[string]string),
-	}
+func NewMatchNoneQuery() *MatchNoneQuery {
+	q := &MatchNoneQuery{newFtsQueryBase()}
+	q.options["match_none"] = nil
+	return q
 }
 
 // TermRangeQuery represents a FTS term range query.

--- a/cbft/query.go
+++ b/cbft/query.go
@@ -511,11 +511,14 @@ func (q *PrefixQuery) Boost(boost float32) *PrefixQuery {
 
 // MatchAllQuery represents a FTS match all query.
 type MatchAllQuery struct {
+	MatchAll map[string]string `json:"match_all"`
 }
 
 // NewMatchAllQuery creates a new MatchAllQuery.
-func NewMatchAllQuery(prefix string) *MatchAllQuery {
-	return &MatchAllQuery{}
+func NewMatchAllQuery() *MatchAllQuery {
+	return &MatchAllQuery{
+		MatchAll: make(map[string]string),
+	}
 }
 
 // MatchNoneQuery represents a FTS match none query.


### PR DESCRIPTION
Hi,

currently the query MatchAll and MatchNone doesn't work because when the json marshalling of the query occurred, it returns an empty json instead of `{ "match_all": {} }` (for match all query).

So the only way I find to produce the correct json is to add an attribute and initialize an empty map.

Maybe there is a more elegant way to do it :/