### PR TITLE
return response.Status as error message when neither error nor data e…

### DIFF
--- a/bucketmgr.go
+++ b/bucketmgr.go
@@ -110,10 +110,17 @@ func (bm *BucketManager) Flush() error {
 		if err != nil {
 			return err
 		}
+
 		err = resp.Body.Close()
 		if err != nil {
 			logDebugf("Failed to close socket (%s)", err)
 		}
+
+		// handles responses like unauthorized which does not returns any error or data
+		if len(data) == 0 {
+			return clientError{resp.Status}
+		}
+
 		return clientError{string(data)}
 	}
 	return nil

--- a/bucketmgr.go
+++ b/bucketmgr.go
@@ -144,6 +144,10 @@ func (bm *BucketManager) GetDesignDocument(name string) (*DesignDocument, error)
 		if err != nil {
 			logDebugf("Failed to close socket (%s)", err)
 		}
+		// handles responses like unauthorized which does not returns any error or data
+		if len(data) == 0 {
+			return nil, clientError{resp.Status}
+		}
 		return nil, clientError{string(data)}
 	}
 
@@ -175,6 +179,10 @@ func (bm *BucketManager) GetDesignDocuments() ([]*DesignDocument, error) {
 		err = resp.Body.Close()
 		if err != nil {
 			logDebugf("Failed to close socket (%s)", err)
+		}
+		// handles responses like unauthorized which does not returns any error or data
+		if len(data) == 0 {
+			return nil, clientError{resp.Status}
 		}
 		return nil, clientError{string(data)}
 	}
@@ -238,6 +246,10 @@ func (bm *BucketManager) UpsertDesignDocument(ddoc *DesignDocument) error {
 		if err != nil {
 			logDebugf("Failed to close socket (%s)", err)
 		}
+		// handles responses like unauthorized which does not returns any error or data
+		if len(data) == 0 {
+			return clientError{resp.Status}
+		}
 		return clientError{string(data)}
 	}
 
@@ -261,6 +273,10 @@ func (bm *BucketManager) RemoveDesignDocument(name string) error {
 		err = resp.Body.Close()
 		if err != nil {
 			logDebugf("Failed to close socket (%s)", err)
+		}
+		// handles responses like unauthorized which does not returns any error or data
+		if len(data) == 0 {
+			return clientError{resp.Status}
 		}
 		return clientError{string(data)}
 	}


### PR DESCRIPTION
I've added response.Status as error message. Because when you give an invalid password bucket.Manager() it returns error with empty message. So I made a development to clarify error.