### PR TITLE
Remove deprecated request cancel

### DIFF
--- a/util.go
+++ b/util.go
@@ -19,7 +19,7 @@ func doHttpWithTimeout(cli *http.Client, req *http.Request, timeout time.Duratio
 
 	ctx, cancel := context.WithTimeout(req.Context(), timeout)
 	defer cancel()
-	req.WithContext(ctx)
+	req = req.WithContext(ctx)
 
 	resp, err = cli.Do(req)
 	return

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package gocb
 
 import (
+	"context"
 	"net/http"
 	"time"
 )
@@ -16,13 +17,10 @@ func doHttpWithTimeout(cli *http.Client, req *http.Request, timeout time.Duratio
 		return
 	}
 
-	tmoch := make(chan struct{})
-	timer := time.AfterFunc(timeout, func() {
-		tmoch <- struct{}{}
-	})
+	ctx, cancel := context.WithTimeout(req.Context(), timeout)
+	defer cancel()
+	req.WithContext(ctx)
 
-	req.Cancel = tmoch
 	resp, err = cli.Do(req)
-	timer.Stop()
 	return
 }


### PR DESCRIPTION
As it states in http.request.go file:

> // Deprecated: Use the Context and WithContext methods
> // instead. If a Request's Cancel field and context are both
> // set, it is undefined whether Cancel is respected.
> Cancel <-chan struct{}

So I replaced it with context.WithTimeout.