### PR TITLE
fixed bug in UpsertUser regarding Global Role handling.

### DIFF
--- a/cluster_usermgr.go
+++ b/cluster_usermgr.go
@@ -409,7 +409,11 @@ func (um *UserManager) UpsertUser(user User, opts *UpsertUserOptions) error {
 
 	var reqRoleStrs []string
 	for _, roleData := range user.Roles {
-		reqRoleStrs = append(reqRoleStrs, fmt.Sprintf("%s[%s]", roleData.Name, roleData.Bucket))
+		if roleData.Bucket == "" {
+			reqRoleStrs = append(reqRoleStrs, fmt.Sprintf("%s", roleData.Name))
+		} else {
+			reqRoleStrs = append(reqRoleStrs, fmt.Sprintf("%s[%s]", roleData.Name, roleData.Bucket))
+		}
 	}
 
 	reqForm := make(url.Values)


### PR DESCRIPTION
The current code always appends brackets [] regardless of whether the role you want to add requires them or not. For example using the Role

```golang
user := gocb.User{
    Username: username,
    DisplayName: usernameConfig.DisplayName,
    Password: password,
    Roles: []gocb.Role{
        {
            Name: "ro_admin",
        },
    },
}
```

produces this **error** from the couchbase server...

couchbase_test.go:140: err: {"errors":{"roles":"Cannot assign roles to user because the following roles are unknown, malformed or role parameters are undefined: [ro_admin[]]"}} | {"unique_id":"157521e8-de25-4a23-b76b-fb7164a6b006","endpoint":"http://localhost:8091"}

**The gocb client generates this request to the server...**

PUT /settings/rbac/users/local/v-test-test-1YY4qZyJH6FzMmITe5YV-1589064428 HTTP/1.1
Host: localhost:8091
User-Agent: {"a":"gocbcore/v9.0.0 gocb/v2.1.0","i":"c00126f6-12fb-4259-b175-75a6d8af5dbf"}
Transfer-Encoding: chunked
Authorization: Basic QWRtaW5pc3RyYXRvcjpBZG1pbjEyMw==
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip

name=test&password=A1a-fgSrWXPJygyJMWkL&roles=ro_admin%5B%5

**where the cli client correctly produces this request...**

PUT /settings/rbac/users/local/jdoe HTTP/1.1
Host: 127.0.0.1:8091
User-Agent: couchbase-cli 6.5.1-6299
Accept-Encoding: gzip, deflate
Accept: /
Connection: keep-alive
Content-Length: 52
Content-Type: application/x-www-form-urlencoded
Authorization: Basic QWRtaW5pc3RyYXRvcjpBZG1pbjEyMw==

name=John+Doe&password=cbpass&roles=ro_admin&groups=