### PR TITLE
ViewOptions. Don't set group if group_level is not zero

### DIFF
--- a/viewquery_options.go
+++ b/viewquery_options.go
@@ -109,14 +109,15 @@ func (opts *ViewOptions) toURLValues() (*url.Values, error) {
 	if opts.Reduce {
 		options.Set("reduce", "true")
 
-		// Only set group if a reduce view
-		options.Set("group", "false") // is this line necessary?
-		if opts.Group {
-			options.Set("group", "true")
-		}
-
 		if opts.GroupLevel != 0 {
 			options.Set("group_level", strconv.FormatUint(uint64(opts.GroupLevel), 10))
+		} else {
+			// Only set group if a reduce view and grouplevel == 0
+			if opts.Group {
+				options.Set("group", "true")
+			} else {
+				options.Set("group", "false") // is this line necessary?
+			}
 		}
 	}
 


### PR DESCRIPTION
Since couchbase 6.5, group and group_level can not be set together when doing view query.