### PR TITLE
Add type to const declarations to improve docs

### DIFF
--- a/analyticsquery_options.go
+++ b/analyticsquery_options.go
@@ -12,9 +12,9 @@ type AnalyticsScanConsistency uint
 
 const (
 	// AnalyticsScanConsistencyNotBounded indicates no data consistency is required.
-	AnalyticsScanConsistencyNotBounded = AnalyticsScanConsistency(1)
+	AnalyticsScanConsistencyNotBounded AnalyticsScanConsistency = iota + 1
 	// AnalyticsScanConsistencyRequestPlus indicates that request-level data consistency is required.
-	AnalyticsScanConsistencyRequestPlus = AnalyticsScanConsistency(2)
+	AnalyticsScanConsistencyRequestPlus
 )
 
 // AnalyticsOptions is the set of options available to an Analytics query.

--- a/bucket_viewindexes.go
+++ b/bucket_viewindexes.go
@@ -15,10 +15,10 @@ type DesignDocumentNamespace uint
 
 const (
 	// DesignDocumentNamespaceProduction means that a design document resides in the production namespace.
-	DesignDocumentNamespaceProduction = DesignDocumentNamespace(0)
+	DesignDocumentNamespaceProduction DesignDocumentNamespace = iota
 
 	// DesignDocumentNamespaceDevelopment means that a design document resides in the development namespace.
-	DesignDocumentNamespaceDevelopment = DesignDocumentNamespace(1)
+	DesignDocumentNamespaceDevelopment
 )
 
 // View represents a Couchbase view within a design document.

--- a/cluster_bucketmgr.go
+++ b/cluster_bucketmgr.go
@@ -17,13 +17,13 @@ type BucketType string
 
 const (
 	// CouchbaseBucketType indicates a Couchbase bucket type.
-	CouchbaseBucketType = BucketType("membase")
+	CouchbaseBucketType BucketType = "membase"
 
 	// MemcachedBucketType indicates a Memcached bucket type.
-	MemcachedBucketType = BucketType("memcached")
+	MemcachedBucketType BucketType = "memcached"
 
 	// EphemeralBucketType indicates an Ephemeral bucket type.
-	EphemeralBucketType = BucketType("ephemeral")
+	EphemeralBucketType BucketType = "ephemeral"
 )
 
 // ConflictResolutionType specifies the kind of conflict resolution to use for a bucket.
@@ -31,10 +31,10 @@ type ConflictResolutionType string
 
 const (
 	// ConflictResolutionTypeTimestamp specifies to use timestamp conflict resolution on the bucket.
-	ConflictResolutionTypeTimestamp = ConflictResolutionType("lww")
+	ConflictResolutionTypeTimestamp ConflictResolutionType = "lww"
 
 	// ConflictResolutionTypeSequenceNumber specifies to use sequence number conflict resolution on the bucket.
-	ConflictResolutionTypeSequenceNumber = ConflictResolutionType("seqno")
+	ConflictResolutionTypeSequenceNumber ConflictResolutionType = "seqno"
 )
 
 // EvictionPolicyType specifies the kind of eviction policy to use for a bucket.
@@ -42,10 +42,10 @@ type EvictionPolicyType string
 
 const (
 	// EvictionPolicyTypeFull specifies to use full eviction for a bucket.
-	EvictionPolicyTypeFull = EvictionPolicyType("fullEviction")
+	EvictionPolicyTypeFull EvictionPolicyType = "fullEviction"
 
 	// EvictionPolicyTypeValueOnly specifies to use value only eviction for a bucket.
-	EvictionPolicyTypeValueOnly = EvictionPolicyType("valueOnly")
+	EvictionPolicyTypeValueOnly EvictionPolicyType = "valueOnly"
 )
 
 // CompressionMode specifies the kind of compression to use for a bucket.
@@ -53,13 +53,13 @@ type CompressionMode string
 
 const (
 	// CompressionModeOff specifies to use no compression for a bucket.
-	CompressionModeOff = CompressionMode("off")
+	CompressionModeOff CompressionMode = "off"
 
 	// CompressionModePassive specifies to use passive compression for a bucket.
-	CompressionModePassive = CompressionMode("passive")
+	CompressionModePassive CompressionMode = "passive"
 
 	// CompressionModeActive specifies to use active compression for a bucket.
-	CompressionModeActive = CompressionMode("active")
+	CompressionModeActive CompressionMode = "active"
 )
 
 type jsonBucketSettings struct {

--- a/collection_subdoc.go
+++ b/collection_subdoc.go
@@ -122,13 +122,13 @@ type StoreSemantics uint8
 const (
 	// StoreSemanticsReplace signifies to Replace the document, and fail if it does not exist.
 	// This is the default action
-	StoreSemanticsReplace = StoreSemantics(0)
+	StoreSemanticsReplace StoreSemantics = iota
 
 	// StoreSemanticsUpsert signifies to replace the document or create it if it doesn't exist.
-	StoreSemanticsUpsert = StoreSemantics(1)
+	StoreSemanticsUpsert
 
 	// StoreSemanticsInsert signifies to create the document, and fail if it exists.
-	StoreSemanticsInsert = StoreSemantics(2)
+	StoreSemanticsInsert
 )
 
 // MutateInOptions are the set of options available to MutateIn.

--- a/constants.go
+++ b/constants.go
@@ -14,10 +14,10 @@ type QueryIndexType string
 
 const (
 	// QueryIndexTypeGsi indicates that GSI was used to build the index.
-	QueryIndexTypeGsi = QueryIndexType("gsi")
+	QueryIndexTypeGsi QueryIndexType = "gsi"
 
 	// QueryIndexTypeView indicates that views were used to build the index.
-	QueryIndexTypeView = QueryIndexType("views")
+	QueryIndexTypeView QueryIndexType = "views"
 )
 
 // QueryStatus provides information about the current status of a query.
@@ -25,34 +25,34 @@ type QueryStatus string
 
 const (
 	// QueryStatusRunning indicates the query is still running
-	QueryStatusRunning = QueryStatus("running")
+	QueryStatusRunning QueryStatus = "running"
 
 	// QueryStatusSuccess indicates the query was successful.
-	QueryStatusSuccess = QueryStatus("success")
+	QueryStatusSuccess QueryStatus = "success"
 
 	// QueryStatusErrors indicates a query completed with errors.
-	QueryStatusErrors = QueryStatus("errors")
+	QueryStatusErrors QueryStatus = "errors"
 
 	// QueryStatusCompleted indicates a query has completed.
-	QueryStatusCompleted = QueryStatus("completed")
+	QueryStatusCompleted QueryStatus = "completed"
 
 	// QueryStatusStopped indicates a query has been stopped.
-	QueryStatusStopped = QueryStatus("stopped")
+	QueryStatusStopped QueryStatus = "stopped"
 
 	// QueryStatusTimeout indicates a query timed out.
-	QueryStatusTimeout = QueryStatus("timeout")
+	QueryStatusTimeout QueryStatus = "timeout"
 
 	// QueryStatusClosed indicates that a query was closed.
-	QueryStatusClosed = QueryStatus("closed")
+	QueryStatusClosed QueryStatus = "closed"
 
 	// QueryStatusFatal indicates that a query ended with a fatal error.
-	QueryStatusFatal = QueryStatus("fatal")
+	QueryStatusFatal QueryStatus = "fatal"
 
 	// QueryStatusAborted indicates that a query was aborted.
-	QueryStatusAborted = QueryStatus("aborted")
+	QueryStatusAborted QueryStatus = "aborted"
 
 	// QueryStatusUnknown indicates that the query status is unknown.
-	QueryStatusUnknown = QueryStatus("unknown")
+	QueryStatusUnknown QueryStatus = "unknown"
 )
 
 // ServiceType specifies a particular Couchbase service type.
@@ -60,22 +60,22 @@ type ServiceType gocbcore.ServiceType
 
 const (
 	// ServiceTypeManagement represents a management service.
-	ServiceTypeManagement = ServiceType(gocbcore.MgmtService)
+	ServiceTypeManagement ServiceType = ServiceType(gocbcore.MgmtService)
 
 	// ServiceTypeKeyValue represents a memcached service.
-	ServiceTypeKeyValue = ServiceType(gocbcore.MemdService)
+	ServiceTypeKeyValue ServiceType = ServiceType(gocbcore.MemdService)
 
 	// ServiceTypeViews represents a views service.
-	ServiceTypeViews = ServiceType(gocbcore.CapiService)
+	ServiceTypeViews ServiceType = ServiceType(gocbcore.CapiService)
 
 	// ServiceTypeQuery represents a query service.
-	ServiceTypeQuery = ServiceType(gocbcore.N1qlService)
+	ServiceTypeQuery ServiceType = ServiceType(gocbcore.N1qlService)
 
 	// ServiceTypeSearch represents a full-text-search service.
-	ServiceTypeSearch = ServiceType(gocbcore.FtsService)
+	ServiceTypeSearch ServiceType = ServiceType(gocbcore.FtsService)
 
 	// ServiceTypeAnalytics represents an analytics service.
-	ServiceTypeAnalytics = ServiceType(gocbcore.CbasService)
+	ServiceTypeAnalytics ServiceType = ServiceType(gocbcore.CbasService)
 )
 
 // QueryProfileMode specifies the profiling mode to use during a query.
@@ -83,13 +83,13 @@ type QueryProfileMode string
 
 const (
 	// QueryProfileModeNone disables query profiling
-	QueryProfileModeNone = QueryProfileMode("off")
+	QueryProfileModeNone QueryProfileMode = "off"
 
 	// QueryProfileModePhases includes phase profiling information in the query response
-	QueryProfileModePhases = QueryProfileMode("phases")
+	QueryProfileModePhases QueryProfileMode = "phases"
 
 	// QueryProfileModeTimings includes timing profiling information in the query response
-	QueryProfileModeTimings = QueryProfileMode("timings")
+	QueryProfileModeTimings QueryProfileMode = "timings"
 )
 
 // SubdocFlag provides special handling flags for sub-document operations
@@ -97,17 +97,17 @@ type SubdocFlag memd.SubdocFlag
 
 const (
 	// SubdocFlagNone indicates no special behaviours
-	SubdocFlagNone = SubdocFlag(memd.SubdocFlagNone)
+	SubdocFlagNone SubdocFlag = SubdocFlag(memd.SubdocFlagNone)
 
 	// SubdocFlagCreatePath indicates you wish to recursively create the tree of paths
 	// if it does not already exist within the document.
-	SubdocFlagCreatePath = SubdocFlag(memd.SubdocFlagMkDirP)
+	SubdocFlagCreatePath SubdocFlag = SubdocFlag(memd.SubdocFlagMkDirP)
 
 	// SubdocFlagXattr indicates your path refers to an extended attribute rather than the document.
-	SubdocFlagXattr = SubdocFlag(memd.SubdocFlagXattrPath)
+	SubdocFlagXattr SubdocFlag = SubdocFlag(memd.SubdocFlagXattrPath)
 
 	// SubdocFlagUseMacros indicates that you wish macro substitution to occur on the value
-	SubdocFlagUseMacros = SubdocFlag(memd.SubdocFlagExpandMacros)
+	SubdocFlagUseMacros SubdocFlag = SubdocFlag(memd.SubdocFlagExpandMacros)
 )
 
 // SubdocDocFlag specifies document-level flags for a sub-document operation.
@@ -115,16 +115,16 @@ type SubdocDocFlag memd.SubdocDocFlag
 
 const (
 	// SubdocDocFlagNone indicates no special behaviours
-	SubdocDocFlagNone = SubdocDocFlag(memd.SubdocDocFlagNone)
+	SubdocDocFlagNone SubdocDocFlag = SubdocDocFlag(memd.SubdocDocFlagNone)
 
 	// SubdocDocFlagMkDoc indicates that the document should be created if it does not already exist.
-	SubdocDocFlagMkDoc = SubdocDocFlag(memd.SubdocDocFlagMkDoc)
+	SubdocDocFlagMkDoc SubdocDocFlag = SubdocDocFlag(memd.SubdocDocFlagMkDoc)
 
 	// SubdocDocFlagAddDoc indices that the document should be created only if it does not already exist.
-	SubdocDocFlagAddDoc = SubdocDocFlag(memd.SubdocDocFlagAddDoc)
+	SubdocDocFlagAddDoc SubdocDocFlag = SubdocDocFlag(memd.SubdocDocFlagAddDoc)
 
 	// SubdocDocFlagAccessDeleted indicates that you wish to receive soft-deleted documents.
-	SubdocDocFlagAccessDeleted = SubdocDocFlag(memd.SubdocDocFlagAccessDeleted)
+	SubdocDocFlagAccessDeleted SubdocDocFlag = SubdocDocFlag(memd.SubdocDocFlagAccessDeleted)
 )
 
 // DurabilityLevel specifies the level of synchronous replication to use.
@@ -132,15 +132,15 @@ type DurabilityLevel uint8
 
 const (
 	// DurabilityLevelMajority specifies that a mutation must be replicated (held in memory) to a majority of nodes.
-	DurabilityLevelMajority = DurabilityLevel(1)
+	DurabilityLevelMajority DurabilityLevel = iota + 1
 
 	// DurabilityLevelMajorityAndPersistOnMaster specifies that a mutation must be replicated (held in memory) to a
 	// majority of nodes and also persisted (written to disk) on the active node.
-	DurabilityLevelMajorityAndPersistOnMaster = DurabilityLevel(2)
+	DurabilityLevelMajorityAndPersistOnMaster
 
 	// DurabilityLevelPersistToMajority specifies that a mutation must be persisted (written to disk) to a majority
 	// of nodes.
-	DurabilityLevelPersistToMajority = DurabilityLevel(3)
+	DurabilityLevelPersistToMajority
 )
 
 // MutationMacro can be supplied to MutateIn operations to perform ExpandMacros operations.
@@ -148,13 +148,13 @@ type MutationMacro string
 
 const (
 	// MutationMacroCAS can be used to tell the server to use the CAS macro.
-	MutationMacroCAS = MutationMacro("\"${Mutation.CAS}\"")
+	MutationMacroCAS MutationMacro = "\"${Mutation.CAS}\""
 
 	// MutationMacroSeqNo can be used to tell the server to use the seqno macro.
-	MutationMacroSeqNo = MutationMacro("\"${Mutation.seqno}\"")
+	MutationMacroSeqNo MutationMacro = "\"${Mutation.seqno}\""
 
 	// MutationMacroValueCRC32c can be used to tell the server to use the value_crc32c macro.
-	MutationMacroValueCRC32c = MutationMacro("\"${Mutation.value_crc32c}\"")
+	MutationMacroValueCRC32c MutationMacro = "\"${Mutation.value_crc32c}\""
 )
 
 // ClusterState specifies the current state of the cluster
@@ -162,13 +162,13 @@ type ClusterState uint
 
 const (
 	// ClusterStateOnline indicates that all nodes are online and reachable.
-	ClusterStateOnline = ClusterState(1)
+	ClusterStateOnline ClusterState = iota + 1
 
 	// ClusterStateDegraded indicates that all services will function, but possibly not optimally.
-	ClusterStateDegraded = ClusterState(2)
+	ClusterStateDegraded
 
 	// ClusterStateOffline indicates that no nodes were reachable.
-	ClusterStateOffline = ClusterState(3)
+	ClusterStateOffline
 )
 
 // EndpointState specifies the current state of an endpoint.
@@ -176,16 +176,16 @@ type EndpointState uint
 
 const (
 	// EndpointStateDisconnected indicates the endpoint socket is unreachable.
-	EndpointStateDisconnected = EndpointState(1)
+	EndpointStateDisconnected EndpointState = iota + 1
 
 	// EndpointStateConnecting indicates the endpoint socket is connecting.
-	EndpointStateConnecting = EndpointState(2)
+	EndpointStateConnecting
 
 	// EndpointStateConnected indicates the endpoint socket is connected and ready.
-	EndpointStateConnected = EndpointState(3)
+	EndpointStateConnected
 
 	// EndpointStateDisconnecting indicates the endpoint socket is disconnecting.
-	EndpointStateDisconnecting = EndpointState(4)
+	EndpointStateDisconnecting
 )
 
 // PingState specifies the result of the ping operation
@@ -193,11 +193,11 @@ type PingState uint
 
 const (
 	// PingStateOk indicates that the ping operation was successful.
-	PingStateOk = PingState(1)
+	PingStateOk PingState = iota + 1
 
 	// PingStateTimeout indicates that the ping operation timed out.
-	PingStateTimeout = PingState(2)
+	PingStateTimeout
 
 	// PingStateError indicates that the ping operation failed.
-	PingStateError = PingState(3)
+	PingStateError
 )

--- a/logging.go
+++ b/logging.go
@@ -14,13 +14,13 @@ type LogLevel gocbcore.LogLevel
 // Various logging levels (or subsystems) which can categorize the message.
 // Currently these are ordered in decreasing severity.
 const (
-	LogError        = LogLevel(gocbcore.LogError)
-	LogWarn         = LogLevel(gocbcore.LogWarn)
-	LogInfo         = LogLevel(gocbcore.LogInfo)
-	LogDebug        = LogLevel(gocbcore.LogDebug)
-	LogTrace        = LogLevel(gocbcore.LogTrace)
-	LogSched        = LogLevel(gocbcore.LogSched)
-	LogMaxVerbosity = LogLevel(gocbcore.LogMaxVerbosity)
+	LogError        LogLevel = LogLevel(gocbcore.LogError)
+	LogWarn         LogLevel = LogLevel(gocbcore.LogWarn)
+	LogInfo         LogLevel = LogLevel(gocbcore.LogInfo)
+	LogDebug        LogLevel = LogLevel(gocbcore.LogDebug)
+	LogTrace        LogLevel = LogLevel(gocbcore.LogTrace)
+	LogSched        LogLevel = LogLevel(gocbcore.LogSched)
+	LogMaxVerbosity LogLevel = LogLevel(gocbcore.LogMaxVerbosity)
 )
 
 // LogRedactLevel specifies the degree with which to redact the logs.
@@ -28,13 +28,13 @@ type LogRedactLevel uint
 
 const (
 	// RedactNone indicates to perform no redactions
-	RedactNone = LogRedactLevel(0)
+	RedactNone LogRedactLevel = iota
 
 	// RedactPartial indicates to redact all possible user-identifying information from logs.
-	RedactPartial = LogRedactLevel(1)
+	RedactPartial
 
 	// RedactFull indicates to fully redact all possible identifying information from logs.
-	RedactFull = LogRedactLevel(2)
+	RedactFull
 )
 
 // SetLogRedactionLevel specifies the level with which logs should be redacted.

--- a/query_options.go
+++ b/query_options.go
@@ -13,9 +13,9 @@ type QueryScanConsistency uint
 
 const (
 	// QueryScanConsistencyNotBounded indicates no data consistency is required.
-	QueryScanConsistencyNotBounded = QueryScanConsistency(1)
+	QueryScanConsistencyNotBounded QueryScanConsistency = iota + 1
 	// QueryScanConsistencyRequestPlus indicates that request-level data consistency is required.
-	QueryScanConsistencyRequestPlus = QueryScanConsistency(2)
+	QueryScanConsistencyRequestPlus
 )
 
 // QueryOptions represents the options available when executing a query.

--- a/searchquery_options.go
+++ b/searchquery_options.go
@@ -11,23 +11,23 @@ type SearchHighlightStyle string
 
 const (
 	// DefaultHighlightStyle specifies to use the default to highlight search result hits.
-	DefaultHighlightStyle = SearchHighlightStyle("")
+	DefaultHighlightStyle SearchHighlightStyle = ""
 
 	// HTMLHighlightStyle specifies to use HTML tags to highlight search result hits.
-	HTMLHighlightStyle = SearchHighlightStyle("html")
+	HTMLHighlightStyle SearchHighlightStyle = "html"
 
 	// AnsiHightlightStyle specifies to use ANSI tags to highlight search result hits.
-	AnsiHightlightStyle = SearchHighlightStyle("ansi")
+	AnsiHightlightStyle SearchHighlightStyle = "ansi"
 )
 
 // SearchScanConsistency indicates the level of data consistency desired for a search query.
 type SearchScanConsistency uint
 
 const (
-	searchScanConsistencyNotSet = SearchScanConsistency(0)
+	searchScanConsistencyNotSet SearchScanConsistency = iota
 
 	// SearchScanConsistencyNotBounded indicates no data consistency is required.
-	SearchScanConsistencyNotBounded = SearchScanConsistency(1)
+	SearchScanConsistencyNotBounded
 )
 
 // SearchHighlightOptions are the options available for search highlighting.

--- a/viewquery_options.go
+++ b/viewquery_options.go
@@ -13,11 +13,11 @@ type ViewScanConsistency uint
 
 const (
 	// ViewScanConsistencyNotBounded indicates that no special behaviour should be used.
-	ViewScanConsistencyNotBounded = ViewScanConsistency(1)
+	ViewScanConsistencyNotBounded ViewScanConsistency = iota + 1
 	// ViewScanConsistencyRequestPlus indicates to update the index before querying it.
-	ViewScanConsistencyRequestPlus = ViewScanConsistency(2)
+	ViewScanConsistencyRequestPlus
 	// ViewScanConsistencyUpdateAfter indicates to update the index asynchronously after querying.
-	ViewScanConsistencyUpdateAfter = ViewScanConsistency(3)
+	ViewScanConsistencyUpdateAfter
 )
 
 // ViewOrdering specifies the ordering for the view queries results.
@@ -25,9 +25,9 @@ type ViewOrdering uint
 
 const (
 	// ViewOrderingAscending indicates the query results should be sorted from lowest to highest.
-	ViewOrderingAscending = ViewOrdering(1)
+	ViewOrderingAscending ViewOrdering = iota + 1
 	// ViewOrderingDescending indicates the query results should be sorted from highest to lowest.
-	ViewOrderingDescending = ViewOrdering(2)
+	ViewOrderingDescending
 )
 
 // ViewErrorMode pecifies the behaviour of the query engine should an error occur during the gathering of
@@ -36,10 +36,10 @@ type ViewErrorMode uint
 
 const (
 	// ViewErrorModeContinue indicates to continue gathering results on error.
-	ViewErrorModeContinue = ViewErrorMode(1)
+	ViewErrorModeContinue ViewErrorMode = iota + 1
 
 	// ViewErrorModeStop indicates to stop gathering results on error
-	ViewErrorModeStop = ViewErrorMode(2)
+	ViewErrorModeStop
 )
 
 // ViewOptions represents the options available when executing view query.


### PR DESCRIPTION
Add type to const declarations to improve docs and use iota where possible to initialize constants.

The way constants were previously defined did not cause their
documentation to be included with the type definition documentation.
This is corrected by explicitly adding the type to the const
declaration. Like so:
```go
        type X int
        const (
                X0 X = iota
                X1
                X2
        )
```
as opposed to
```go
        type X int
        const (
                X0 = X(1)
                X1 = X(2)
                X2 = X(3)
        )
```

This causes the constants to appear under their type definition when using `go doc`.

Before this patch:
```
$ go doc QueryStatus
package gocb // import "."

type QueryStatus string
    QueryStatus provides information about the current status of a query.

```

After this patch:
```
$ go doc QueryStatus
package gocb // import "."

type QueryStatus string
    QueryStatus provides information about the current status of a query.

const QueryStatusRunning QueryStatus = "running" ...
```

This also uses `iota` to initialize numeric constants. This is a cleaner way to assign the type and value on a set of constants and is more idiomatic. https://yourbasic.org/golang/iota/

No constant values or types are altered by this change.