### PR TITLE
add conn buff size configuretion option to cluster client config

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,8 +3,9 @@ package gocb
 import (
 	"crypto/x509"
 	"errors"
-	"github.com/couchbase/gocbcore/v10"
 	"sync"
+
+	"github.com/couchbase/gocbcore/v10"
 )
 
 type connectionManager interface {
@@ -67,7 +68,8 @@ func (c *stdConnectionMgr) buildConfig(cluster *Cluster) error {
 				UseOutOfOrderResponses: true,
 			},
 			KVConfig: gocbcore.KVConfig{
-				ConnectTimeout: cluster.timeoutsConfig.ConnectTimeout,
+				ConnectTimeout:       cluster.timeoutsConfig.ConnectTimeout,
+				ConnectionBufferSize: cluster.internalConfig.ConnectionBufferSize,
 			},
 			DefaultRetryStrategy: cluster.retryStrategyWrapper,
 			CircuitBreakerConfig: gocbcore.CircuitBreakerConfig{

--- a/cluster.go
+++ b/cluster.go
@@ -100,7 +100,8 @@ type CompressionConfig struct {
 // items.
 // Internal: This should never be used and is not supported.
 type InternalConfig struct {
-	TLSRootCAProvider func() *x509.CertPool
+	TLSRootCAProvider    func() *x509.CertPool
+	ConnectionBufferSize uint
 }
 
 // ClusterOptions is the set of options available for creating a Cluster.


### PR DESCRIPTION
This PR is resolves: https://issues.couchbase.com/browse/GOCBC-1238

It is fixed on gocbcore but not on this (gocb) repository.

With this PR users will be able to configure their connection buffer size.

This really impacts our production environments, should I need to open a pr for v2.6.0 tag to v2.6.1?