### PR TITLE
Proposal For Use Of Interfaces

### DIFF
--- a/collection_crud.go
+++ b/collection_crud.go
@@ -183,7 +183,7 @@ type ExistsOptions struct {
 }
 
 // Exists checks if a document exists for the given id.
-func (c *Collection) Exists(id string, opts *ExistsOptions) (docOut *ExistsResult, errOut error) {
+func (c *Collection) Exists(id string, opts *ExistsOptions) (docOut ExistsResult, errOut error) {
 	if opts == nil {
 		opts = &ExistsOptions{}
 	}

--- a/kvprovider.go
+++ b/kvprovider.go
@@ -11,7 +11,7 @@ type kvProvider interface {
 	Remove(*Collection, string, *RemoveOptions) (*MutationResult, error)                // Done
 
 	Get(*Collection, string, *GetOptions) (*GetResult, error)                                // Done
-	Exists(*Collection, string, *ExistsOptions) (*ExistsResult, error)                       // Done
+	Exists(*Collection, string, *ExistsOptions) (ExistsResult, error)                        // Done
 	GetAndTouch(*Collection, string, time.Duration, *GetAndTouchOptions) (*GetResult, error) // Done
 	GetAndLock(*Collection, string, time.Duration, *GetAndLockOptions) (*GetResult, error)   // Done
 	Unlock(*Collection, string, Cas, *UnlockOptions) error                                   // Done

--- a/kvprovider_core.go
+++ b/kvprovider_core.go
@@ -552,7 +552,7 @@ func (p *kvProviderCore) GetAndLock(c *Collection, id string, lockTime time.Dura
 	return getOut, errOut
 }
 
-func (p *kvProviderCore) Exists(c *Collection, id string, opts *ExistsOptions) (*ExistsResult, error) {
+func (p *kvProviderCore) Exists(c *Collection, id string, opts *ExistsOptions) (ExistsResult, error) {
 	opm := newKvOpManagerCore(c, "exists", opts.ParentSpan, p)
 	defer opm.Finish(false)
 
@@ -566,7 +566,7 @@ func (p *kvProviderCore) Exists(c *Collection, id string, opts *ExistsOptions) (
 		return nil, err
 	}
 
-	var docExists *ExistsResult
+	var docExists ExistsResult
 	var errOut error
 	err := opm.Wait(p.agent.GetMeta(gocbcore.GetMetaOptions{
 		Key:            opm.DocumentID(),
@@ -578,8 +578,8 @@ func (p *kvProviderCore) Exists(c *Collection, id string, opts *ExistsOptions) (
 		User:           opm.Impersonate(),
 	}, func(res *gocbcore.GetMetaResult, err error) {
 		if errors.Is(err, ErrDocumentNotFound) {
-			docExists = &ExistsResult{
-				Result: Result{
+			docExists = &existsResult{
+				result: Result{
 					cas: Cas(0),
 				},
 				docExists: false,
@@ -595,8 +595,8 @@ func (p *kvProviderCore) Exists(c *Collection, id string, opts *ExistsOptions) (
 		}
 
 		if res != nil {
-			docExists = &ExistsResult{
-				Result: Result{
+			docExists = &existsResult{
+				result: Result{
 					cas: Cas(res.Cas),
 				},
 				docExists: res.Deleted == 0,

--- a/kvprovider_ps.go
+++ b/kvprovider_ps.go
@@ -603,7 +603,7 @@ func (p *kvProviderPs) GetAndLock(c *Collection, id string, lockTime time.Durati
 	return &resOut, nil
 }
 
-func (p *kvProviderPs) Exists(c *Collection, id string, opts *ExistsOptions) (*ExistsResult, error) {
+func (p *kvProviderPs) Exists(c *Collection, id string, opts *ExistsOptions) (ExistsResult, error) {
 	opm := newKvOpManagerPs(c, "exists", opts.ParentSpan)
 	defer opm.Finish(false)
 
@@ -630,8 +630,8 @@ func (p *kvProviderPs) Exists(c *Collection, id string, opts *ExistsOptions) (*E
 		return nil, err
 	}
 
-	resOut := ExistsResult{
-		Result: Result{
+	resOut := existsResult{
+		result: Result{
 			Cas(res.Cas),
 		},
 		docExists: res.Result,

--- a/results.go
+++ b/results.go
@@ -328,14 +328,23 @@ func (r *LookupInReplicaResult) IsReplica() bool {
 }
 
 // ExistsResult is the return type of Exist operations.
-type ExistsResult struct {
-	Result
+type ExistsResult interface {
+	Exists() bool
+	Result() Result
+}
+
+type existsResult struct {
+	result    Result
 	docExists bool
 }
 
 // Exists returns whether or not the document exists.
-func (d *ExistsResult) Exists() bool {
+func (d *existsResult) Exists() bool {
 	return d.docExists
+}
+
+func (d *existsResult) Result() Result {
+	return d.result
 }
 
 // MutationResult is the return type of any store related operations. It contains Cas and mutation tokens.


### PR DESCRIPTION
## Context

Greetings,

Our development team utilizes the `gocb` package for our platform. When we use external packages such as this, we tend to wrap them in an abstraction that makes our application code easier to understand. Take the snippet below, for example; we are creating our own wrapper package called `store`. The application only has to understand how the `store` package works, and doesn't need to know that behind the scenes it uses `gocb`. This makes it very easy to understand the application code since we are the ones defining those methods.

<details>

<summary>application</summary>

```go
package main

func main() {
    s, err := store.NewStore()
    if err != nil {
        panic(err)
    }

    doesPlatformConfigurationExist, err := s.DoesPlatformConfigurationExist()
    if err != nil {
        panic(err)
    }

    // It is very easy to understand that this code is checking if the platform configuration document
    // exists in the store
    if !doesPlatformConfigurationExist {
        // Handle case for when the platform configuration document does not exist
    }
}
```

</details>

<details>

<summary>wrapper</summary>

```go
package store

import "github.com/couchbase/gocb/v2"

type Store interface {
    DoesPlatformConfigurationExist() (bool, error)
}

type store struct {
    collection *gocb.Collection
}

func NewStore() (Store, error) {
    var store store

    // We can pretend that there is some boilerplate code here for initializing the *gocb.Collecetion object

    return &store, nil
}

func (s *store) DoesPlatformConfigurationExist() (bool, error) {
    var (
        res *gocb.ExistsResult
        err error
    )

    res, err = s.collection.Exists("platform_configuration", nil)
    if err != nil {
        return false, err
    }

    return res.Exists(), nil
}
```

</details>

## Testing

We do not make wrappers solely for comprehensibility, but also for testing. Any code that uses the `store` package will be easy to write unit tests for because the `Store` type is an `interface`. In our unit tests, we can implement our own `mockStore` type that implements the `Store` interface.

The issue we are facing is not that we can't write tests at the application level, which consumes the `store` package, but rather that we cannot test the `store` package itself without creating a true connection to a `Couchbase` instance or cluster. We want to be able to run our unit tests in a CI pipeline where we are not able to connect to `Couchbase`.

The best way that we know how to address this is for the types in `gocb` to be `interfaces` instead of `structs` so that we can manipulate the functionality of the public methods directly in our unit tests. Let's look at the following examples:

### Structs

We can see that with the `structs` approach, we are unable to test every code path. In order to test the cases where the document does and doesn't exist, we have to write additional code in the unit tests to write and remove the expected document from `Couchbase`. And we still are unable to test the case where an error has occurred because we cannot force `Couchbase` to return an error.

<details>

<summary>store.go</summary>

```go
package store

import (
    "os"
    "time"

    "github.com/couchbase/gocb/v2"
)

type Store interface {
    DoesImportantDocumentExist() (bool, error)
}

type store struct {
    collection *gocb.Collection
}

func NewStore() (Store, error) {
    var (
        cluster *gocb.Cluster
        err     error
    )

    cluster, err = gocb.Connect("couchbase://127.0.0.1", gocb.ClusterOptions{
        Authenticator: gocb.PasswordAuthenticator{
            Username: os.Getenv("COUCHBASE_USERNAME"),
            Password: os.Getenv("COUCHBASE_PASSWORD"),
        },
        TimeoutsConfig: gocb.TimeoutsConfig{
            ConnectTimeout: 5 * time.Second,
        },
    })
    if err != nil {
        return nil, err
    }

    return &store{
        collection: cluster.Bucket("demo").DefaultCollection(),
    }, nil
}

func (s *store) DoesImportantDocumentExist() (bool, error) {
    var (
        res *gocb.ExistsResult
        err error
    )

    res, err = s.collection.Exists("important_document", nil)
    if err != nil {
        return false, err
    }

    return res.Exists(), nil
}
```

</details>

<details>

<summary>store_test.go</summary>

```go
package store

import (
    "os"
    "testing"
    "time"

    "github.com/couchbase/gocb/v2"
    "github.com/stretchr/testify/assert"
)

var (
    collection *gocb.Collection
    s          Store
)

func init() {
    var (
        cluster *gocb.Cluster
        err     error
    )

    s, err = NewStore()
    if err != nil {
        panic(err)
    }

    cluster, err = gocb.Connect("couchbase://127.0.0.1", gocb.ClusterOptions{
        Authenticator: gocb.PasswordAuthenticator{
            Username: os.Getenv("COUCHBASE_USERNAME"),
            Password: os.Getenv("COUCHBASE_PASSWORD"),
        },
        TimeoutsConfig: gocb.TimeoutsConfig{
            ConnectTimeout: 5 * time.Second,
        },
    })
    if err != nil {
        panic(err)
    }

    collection = cluster.Bucket("demo").DefaultCollection()
    s = &store{
        collection: collection,
    }
}

func TestExists(t *testing.T) {
    tests := []struct {
        name        string
        errExpected bool
        doesExist   bool
    }{
        {
            name:        "Document exists",
            errExpected: false,
            doesExist:   true,
        },
        {
            name:        "Document does not exist",
            errExpected: false,
            doesExist:   false,
        },
    }

    for _, test := range tests {
        t.Run(test.name, func(t *testing.T) {
            var (
                documentExists bool
                err            error
            )

            if test.doesExist {
                _, err = collection.Upsert("important_document", "some value", nil)
                if err != nil {
                    t.Fatal(err)
                }

                documentExists, err = s.DoesImportantDocumentExist()
                if err != nil {
                    t.Fatal(err)
                }

                assert.True(t, documentExists, "document should exist")
                return
            }

            _, err = collection.Remove("important_document", nil)
            if err != nil {
                t.Fatal(err)
            }

            documentExists, err = s.DoesImportantDocumentExist()
            if err != nil {
                t.Fatal(err)
            }

            assert.False(t, documentExists, "document should not exist")
        })
    }
}
```

</details>

### Interfaces

We can see that with the `interfaces` approach, it is easy to create our own mock version of a `collection`. Another change to note is that the `*gocb.ExistsResult` type has been changed from a `struct pointer` to an `interface` in the `gocb` package. By using an `interface`, `gocb.ExistsResult`, we can create our own types which implement that `interface` in our unit tests, allowing us to test every code path in our wrapper as well as run these unit tests in a pipeline without the need for a connection to a `Couchbase` instance.

<details>

<summary>store.go</summary>

```go
package store

import (
    "os"
    "time"

    "github.com/couchbase/gocb/v2"
)

type Store interface {
    DoesImportantDocumentExist() (bool, error)
}

type collection interface {
    Exists(id string, opts *gocb.ExistsOptions) (docOut gocb.ExistsResult, errOut error)
}

type store struct {
    collection collection
}

func NewStore() (Store, error) {
    cluster, err := gocb.Connect("couchbase://127.0.0.1", gocb.ClusterOptions{
        Authenticator: gocb.PasswordAuthenticator{
            Username: os.Getenv("COUCHBASE_USERNAME"),
            Password: os.Getenv("COUCHBASE_PASSWORD"),
        },
        TimeoutsConfig: gocb.TimeoutsConfig{
            ConnectTimeout: 5 * time.Second,
        },
    })
    if err != nil {
        return nil, err
    }

    return &store{
        collection: cluster.Bucket("demo").DefaultCollection(),
    }, nil
}

func (s *store) DoesImportantDocumentExist() (bool, error) {
    var (
        res gocb.ExistsResult
        err error
    )

    res, err = s.collection.Exists("important_document", nil)
    if err != nil {
        return false, err
    }

    return res.Exists(), nil
}
```

</details>

<details>

<summary>store_test.go</summary>

```go
package store

import (
    "errors"
    "testing"

    "github.com/couchbase/gocb/v2"
    "github.com/stretchr/testify/assert"
)

type mockCollection struct {
    existsFunc func(id string, opts *gocb.ExistsOptions) (docOut gocb.ExistsResult, errOut error)
}

func (m *mockCollection) Exists(id string, opts *gocb.ExistsOptions) (docOut gocb.ExistsResult, errOut error) {
    return m.existsFunc(id, opts)
}

type mockExistsResult struct {
    existsFunc func() bool
    resultFunc func() gocb.Result
}

func (m mockExistsResult) Exists() bool {
    return m.existsFunc()
}

func (m mockExistsResult) Result() gocb.Result {
    return m.resultFunc()
}

func TestExists(t *testing.T) {
    tests := []struct {
        name        string
        errExpected bool
        doesExist   bool
        collection  mockCollection
    }{
        {
            name:        "Document exists",
            errExpected: false,
            doesExist:   true,
            collection: mockCollection{
                existsFunc: func(id string, opts *gocb.ExistsOptions) (docOut gocb.ExistsResult, errOut error) {
                    return mockExistsResult{
                        existsFunc: func() bool {
                            return true
                        },
                    }, nil
                },
            },
        },
        {
            name:        "Document does not exist",
            errExpected: false,
            doesExist:   false,
            collection: mockCollection{
                existsFunc: func(id string, opts *gocb.ExistsOptions) (docOut gocb.ExistsResult, errOut error) {
                    return mockExistsResult{
                        existsFunc: func() bool {
                            return false
                        },
                    }, nil
                },
            },
        },
        {
            name:        "Error",
            errExpected: false,
            doesExist:   false,
            collection: mockCollection{
                existsFunc: func(id string, opts *gocb.ExistsOptions) (docOut gocb.ExistsResult, errOut error) {
                    return nil, errors.New("some kind of error occurred")
                },
            },
        },
    }

    for _, test := range tests {
        t.Run(test.name, func(t *testing.T) {
            s := &store{
                collection: &test.collection,
            }

            documentExists, err := s.DoesImportantDocumentExist()
            if test.errExpected {
                assert.NotNil(t, err)
            } else if test.doesExist {
                assert.True(t, documentExists, "document should exist")
            } else {
                assert.False(t, documentExists, "document should not exist")
            }
        })
    }
}

```

</details>

## What We Are Asking

We are asking the maintainers for this package if they are open to changing the public `structs` in `gocb` to `interfaces` for the reasons listed above. The most obvious reason for why the answer would be `no` is that this would ultimately be a breaking change, and everyone else that uses this package would have to modify their code to work with the `interfaces` instead. Our goal here is really to test our wrapper in an automated fashion as mentioned before, without the need for a `Couchbase` instance. If the maintainers for this package have any solutions outside of the one that we have proposed, I am all ears. The alternative, if no other solution is provided and the maintainers are against the changes we have proposed, is for us to maintain our own fork of `gocb` and make the changes ourselves. We are not entirely against this, but it would be another layer of maintainence since we will need to periodically sync with upstream branch, which could include conflicts.

## Additional Details

The changes that were raised in this Pull Request were the bare minimum amount of changes that were required to get the code snippets from above to work. This Pull Request is not a request to merge these changes, but rather to demonstrate the effort that it took to make our code sample work.
