### PR TITLE
Create profile for easier local development

### DIFF
--- a/config_profile.go
+++ b/config_profile.go
@@ -25,6 +25,10 @@ const (
 	// overwriting any properties that exist on the profile.
 	// VOLATILE: This API is subject to change at any time.
 	ClusterConfigProfileWanDevelopment ClusterConfigProfile = "wan-development"
+
+	// ClusterConfigProfileLocalDevelopment represents a local development profile that can be applied to the ClusterOptions
+	// overwriting any properties that exist on the profile.
+	ClusterConfigProfileLocalDevelopment ClusterConfigProfile = "local-development"
 )
 
 // ApplyProfile will apply a named profile to the ClusterOptions overwriting any properties that
@@ -34,6 +38,22 @@ func (opts *ClusterOptions) ApplyProfile(profile ClusterConfigProfile) error {
 	if profile == ClusterConfigProfileWanDevelopment {
 		opts.TimeoutsConfig = developmentProfile.TimeoutsConfig
 		return nil
+	}
+
+	return makeInvalidArgumentsError("unknown configuration profile")
+}
+
+// WithProfile will apply a multiples named profiles to the ClusterOptions overwriting any properties that
+// exist on the profile.
+func (opts *ClusterOptions) WithProfile(profile ClusterConfigProfile) error {
+	if profile == ClusterConfigProfileWanDevelopment {
+		opts.TimeoutsConfig = developmentProfile.TimeoutsConfig
+		return nil
+	}
+
+	if profile == ClusterConfigProfileLocalDevelopment {
+		opts.TimeoutsConfig = developmentProfile.TimeoutsConfig
+		opts.TransactionsConfig.DurabilityLevel = DurabilityLevelNone
 	}
 
 	return makeInvalidArgumentsError("unknown configuration profile")


### PR DESCRIPTION
For local development with containers or couchbase-community, the durability level is not supported (`DurabilityImpossible`).

Since we already have a `ClusterConfigProfileWanDevelopment` with some presets for WanDevelopment, this PR introduces a `ClusterConfigProfileLocalDevelopment` with presets for working with Couchbase locally.

Later, this can be refactored to use an options pattern and support for multiple presets.
